### PR TITLE
fix frontend email parsing

### DIFF
--- a/backend/backend_app/static/frontend/app.js
+++ b/backend/backend_app/static/frontend/app.js
@@ -168,7 +168,7 @@ new Vue({
                                 return val.indexOf("tel:") >= 0;
                             });
                             var emails = values.filter(function(val) {
-                                return val.indexOf("email:") >= 0;
+                                return val.indexOf("mailto:") >= 0;
                             });
                             item["phone"] = phones.map(function(val) {
                                 return  self.getTextAfterSemi(val);


### PR DESCRIPTION
Example from: https://ecr.wanotify.uw.edu/Patient
email field from telecom field is prefixed with "mailto:" not "email:"